### PR TITLE
Take LDFLAGS into account when linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: $(BINARY)
 
 $(BINARY): $(OBJECTS)
 	@if [ ! -d $(dir $@) ]; then mkdir -p $(dir $@) ; fi
-	$(CXX) $(CFLAGS) $(OBJECTS) -o $(BINARY) $(LIBS)
+	$(CXX) $(CFLAGS) $(OBJECTS) -o $(BINARY) $(LIBS) $(LDFLAGS)
 	
 $(OBJFOLDER)/%.o: $(SRCFOLDER)/%.cpp $(wildcard $(INCFOLDER)/%.h $(INCFOLDER)/%.hpp)
 	@if [ ! -d $(dir $@) ]; then mkdir -p $(dir $@) ; fi


### PR DESCRIPTION
This allows, for example, Void Linux to build this tool with our custom LDFLAGS that enable position independent executables.
