### PR TITLE
Enable starting pulse if not running

### DIFF
--- a/src/painterface.cpp
+++ b/src/painterface.cpp
@@ -261,7 +261,7 @@ bool PAInterface::connect()
 
 	if (pa_threaded_mainloop_start(m_Mainloop))
 		return false;
-	if (pa_context_connect(m_Context, NULL, PA_CONTEXT_NOAUTOSPAWN, NULL))
+	if (pa_context_connect(m_Context, NULL, PA_CONTEXT_NOFLAGS, NULL))
 		return false;
 
 	for (;;)


### PR DESCRIPTION
Fixes #8 and causes PAmix to behave more like pavucontrol.
