### PR TITLE
Use XDG_CONFIG_DIRS rather than XDG_DATA_DIRS for global configuration.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,4 +15,5 @@ pamix_SOURCES = \
 
 man1_MANS = man/pamix.1
 
-dist_data_DATA = pamix.conf
+pkgsysconfdir = $(sysconfdir)
+dist_pkgsysconf_DATA = pamix.conf

--- a/man/pamix.1
+++ b/man/pamix.1
@@ -8,9 +8,9 @@ pamix
 This is a pavucontrol inspired ncurses based pulseaudio mixer for the commandline
 
 .SH CONFIGURATION
-pamix is configured using a file called pamix.conf inside the $XDG_CONFIG_HOME or $XDG_DATA_DIRS directories or their default values, should they not be set.
+pamix is configured using a file called pamix.conf inside the $XDG_CONFIG_HOME or $XDG_CONFIG_DIRS directories or their default values, should they not be set.
 .br
-$XDG_CONFIG_HOME will be preferred over $XDG_DATA_DIRS.
+$XDG_CONFIG_HOME will be preferred over $XDG_CONFIG_DIRS.
 .br
 .start
 .SH COMMANDS

--- a/src/pamix.cpp
+++ b/src/pamix.cpp
@@ -428,9 +428,9 @@ void loadConfiguration()
 	if (Configuration::loadFile(&configuration, path))
 		return;
 
-	char *xdg_data_dirs = getenv("XDG_DATA_DIRS");
+	char *xdg_config_dirs = getenv("XDG_CONFIG_DIRS");
 
-	path = xdg_data_dirs ? xdg_data_dirs : "/usr/share";
+	path = xdg_config_dirs ? xdg_config_dirs : "/etc";
 	path += "/pamix.conf";
 	size_t cpos = path.find(':');
 	while (cpos != std::string::npos)


### PR DESCRIPTION
Set default global configuration dir from /usr/share to /etc
