### PR TITLE
pamix: use default colors if provided by curses

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,10 @@ fi
 # Checks for libraries.
 
 AS_IF([test "$enable_unicode" = "yes"], [PKG_CHECK_MODULES([NCURSES], [ncursesw])], [PKG_CHECK_MODULES([NCURSES], [ncurses])])
+
+AC_SEARCH_LIBS([use_default_colors], [ncurses curses],
+	AC_DEFINE(HAVE_USE_DEFAULT_COLORS, 1, [Define to 1 if the curses library has the function `use_default_colors`. ]))
+
 PKG_CHECK_MODULES([PULSEAUDIO], [libpulse])
 
 # Checks for header files.

--- a/src/pamix.cpp
+++ b/src/pamix.cpp
@@ -405,9 +405,16 @@ void sig_handle_resize(int s)
 void init_colors()
 {
 	start_color();
+#ifdef HAVE_USE_DEFAULT_COLORS
+	use_default_colors();
+	init_pair(1, COLOR_GREEN, -1);
+	init_pair(2, COLOR_YELLOW, -1);
+	init_pair(3, COLOR_RED, -1);
+#else
 	init_pair(1, COLOR_GREEN, 0);
 	init_pair(2, COLOR_YELLOW, 0);
 	init_pair(3, COLOR_RED, 0);
+#endif
 }
 
 void sig_handle(int sig)


### PR DESCRIPTION
Terminals do not always have black specified as their default
color, as color code 0 and the default color are actually
distinct values. curse/ncurses provides the
`use_default_colors()` function call to actually enable using
default colors instead of 0 for drawing backgrounds. As this
function is not included in the standard but an extension to the
curses library, we cannot always use it, though.

Check if curses specifies `use_default_colors` and, if so, use it
to have curses draw background colors with the default color
instead of black. Furthermore, initialize color pairs with -1 as
background color in this case, which directs it to use the
default color.
