### PR TITLE
pamix_functions: do not use argument in `pamix_cycle` fns

### DIFF
--- a/src/pamix_functions.cpp
+++ b/src/pamix_functions.cpp
@@ -44,12 +44,12 @@ void pamix_add_volume(argument_t arg)
 
 void pamix_cycle_next(argument_t arg)
 {
-	cycle_switch(interface, arg.b);
+	cycle_switch(interface, true);
 }
 
 void pamix_cycle_prev(argument_t arg)
 {
-	cycle_switch(interface, arg.b);
+	cycle_switch(interface, false);
 }
 
 void pamix_toggle_lock(argument_t arg)


### PR DESCRIPTION
The `pamix_cycle_prev` and `pamix_cycle_next` functions are used
to cycle through available ports of an entry, either back- or
forwards. But instead of directly calling `cycle_switch` with
either `true` or `false`, which toggle the cycling direction, we
were reading the argument's boolean value and passed that to
`cycle_switch`. As this value was never set, back-cycling does
not work at all.

Fix the issue by directly calling `cycle_switch` with boolean
values instead of using the argument.