### PR TITLE
FIX: default XDG_CONFIG_DIRS directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ ELSE ()
 ENDIF ()
 
 add_executable(pamix ${pamix_SRC})
-install(FILES pamix.conf DESTINATION /etc)
+install(FILES pamix.conf DESTINATION /etc/xdg)
 install(TARGETS pamix DESTINATION bin)
 install(FILES man/pamix.1 DESTINATION share/man/man1)
 


### PR DESCRIPTION
According to [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html),

> If $XDG_CONFIG_DIRS is either not set or empty, a value equal to /etc/xdg should be used. 

In my environment (gentoo linux, installed via portage), /etc/pamix.conf was not read.