### PR TITLE
Using default terminal background color

### DIFF
--- a/src/pamix.cpp
+++ b/src/pamix.cpp
@@ -107,9 +107,16 @@ void sig_handle_resize(int) {
 
 void init_colors() {
 	start_color();
-	init_pair(1, COLOR_GREEN, 0);
-	init_pair(2, COLOR_YELLOW, 0);
-	init_pair(3, COLOR_RED, 0);
+
+	int background;
+	if(use_default_colors() != ERR)
+		background = -1;
+	else
+		background = 0;
+
+	init_pair(1, COLOR_GREEN, background);
+	init_pair(2, COLOR_YELLOW, background);
+	init_pair(3, COLOR_RED, background);
 }
 
 void sig_handle(int) {


### PR DESCRIPTION
This is useful for people who like their terminals transparent