### PR TITLE
PAmix is now in Fedora stable (i.e. 32+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@
 ### Arch ###
 `yaourt -S pamix-git`
 
+### Fedora ###
+
+`dnf install pamix`
+
 ### openSUSE ###
 `zypper in pamix`
 


### PR DESCRIPTION
Result of issue #56.  Adding to the RPM family section.

Signed-off-by: Petr Šabata <contyk@redhat.com>