### PR TITLE
Fix for ncurses 6.3

### DIFF
--- a/src/pamix_ui.cpp
+++ b/src/pamix_ui.cpp
@@ -184,7 +184,7 @@ void pamix_ui::redrawVolumeBars() {
 }
 
 void pamix_ui::drawHeader() const {
-	mvprintw(0, 1, "%d/%d", m_Entries->empty() ? 0 : m_SelectedEntry + 1, m_Entries->size());
+	mvprintw(0, 1, "%d/%d", m_Entries->empty() ? 0 : m_SelectedEntry + 1, (unsigned)m_Entries->size());
 	mvprintw(0, 10, "%s", entryTypeNames[m_EntriesType]);
 }
 

--- a/src/pamix_ui.cpp
+++ b/src/pamix_ui.cpp
@@ -103,7 +103,7 @@ void pamix_ui::redrawAll() {
 		string_maxlen_pct(applicationName, 0.4);
 		if (isSelectedEntry)
 			attron(A_STANDOUT);
-		mvprintw(lineNumber++, 1, applicationName.c_str());
+		mvprintw(lineNumber++, 1, "%s", applicationName.c_str());
 		attroff(A_STANDOUT);
 
 		bool isMuted = entry->m_Mute || averageVolume == PA_VOLUME_MUTED;
@@ -121,7 +121,7 @@ void pamix_ui::redrawAll() {
 			remainingChars -= displayName.length();
 		}
 
-		mvprintw(curY, curX + remainingChars + 1, displayName.c_str());
+		mvprintw(curY, curX + remainingChars + 1, "%s", displayName.c_str());
 		lineNumber++;
 	}
 


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string.

The pull request fixes a few format argument mismatches.