### PR TITLE
Increase cmake_minimum_required: 2.8 -> 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8...3.10)
 project(pamix C)
 
 set(CMAKE_C_STANDARD 99)


### PR DESCRIPTION
CMake v4.0 released recently, and deprecated support to `cmake < 3.5`
If anyone with `cmake >= 4.0` tries to compile this repo, they'll get 
```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
Compatibility with CMake < 3.5 has been removed from CMake.
```

To fix this, just need to increase the `cmake_minimum_required`
This is an issue we're currently facing in https://github.com/NixOS/nixpkgs
ref: https://github.com/NixOS/nixpkgs/pull/450449